### PR TITLE
💄 design : 페이지 style 적용

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,13 @@ import { request } from "@api/api"
 import storage from "@utils/storage"
 import { debounce } from "@utils/optimization"
 import { STORAGE } from "@data/constant"
+import "@style/searchPage.css"
 
 export default function App({ targetEl }) {
   this.state = {
     autoCompleteList: [],
-    autoCompleteVisible: false
+    autoCompleteVisible: false,
+    keyword: null
   }
 
   this.cache = storage.getItem(STORAGE.AUTO_COMPLETE_LIST, {})
@@ -17,7 +19,8 @@ export default function App({ targetEl }) {
     autoComplete.setState({
       ...autoComplete.state,
       autoCompleteList: this.state.autoCompleteList,
-      autoCompleteVisible: this.state.autoCompleteVisible
+      autoCompleteVisible: this.state.autoCompleteVisible,
+      selectedIdx: -1
     })
   }
 
@@ -30,11 +33,15 @@ export default function App({ targetEl }) {
 
   new SearchBar({
     targetEl,
+    initialState: {
+      keyword: this.state.keyword
+    },
     onSubmit: debounce(async (value) => {
       if (!value) {
         this.setState({
           ...this.state,
-          autoCompleteList: []
+          autoCompleteList: [],
+          autoCompleteVisible: false
         })
 
         return
@@ -55,13 +62,16 @@ export default function App({ targetEl }) {
 
       this.setState({
         ...this.state,
-        autoCompleteList
+        autoCompleteList,
+        autoCompleteVisible: autoCompleteList.length > 0
       })
     }, 200),
     onFocus: (visible) => {
+      const { autoCompleteList } = this.state
+
       this.setState({
         ...this.state,
-        autoCompleteVisible: visible
+        autoCompleteVisible: visible && autoCompleteList.length > 0
       })
     }
   })
@@ -70,7 +80,7 @@ export default function App({ targetEl }) {
     targetEl,
     initialState: {
       autoCompleteList: this.state.autoCompleteList,
-      selectedIdx: null,
+      selectedIdx: -1,
       autoCompleteVisible: this.state.autoCompleteVisible
     }
   })

--- a/src/components/domain/SearchBar.js
+++ b/src/components/domain/SearchBar.js
@@ -2,8 +2,27 @@ import { Button, Image, Input } from "@base"
 import { CANCEL_ICON, SEARCH_ICON } from "@data/constant"
 import { createElement } from "@utils/handleElement"
 
-export default function SearchBar({ targetEl, onSubmit, onFocus }) {
+export default function SearchBar({
+  targetEl,
+  initialState,
+  onSubmit,
+  onFocus
+}) {
   const searchBarEl = createElement({ elClassName: "search-bar" })
+
+  this.state = initialState
+
+  this.setState = (nextState) => {
+    this.state = nextState
+  }
+
+  new Image({
+    targetEl: searchBarEl,
+    initialState: {
+      imgUrl: SEARCH_ICON,
+      imgAlt: "search-icon"
+    }
+  })
 
   const searchInput = new Input({
     targetEl: searchBarEl,
@@ -12,10 +31,10 @@ export default function SearchBar({ targetEl, onSubmit, onFocus }) {
       placeholder: "영화 제목을 입력해 주세요."
     },
     onChange: (e) => {
-      const { value } = e.target
-      const keyword = value.trim()
+      const nextKeyword = e.target.value.trim()
+      const { keyword } = this.state
 
-      if (!keyword) {
+      if (!nextKeyword) {
         cancelBtn.reset()
       } else {
         cancelBtn.setState({
@@ -24,15 +43,16 @@ export default function SearchBar({ targetEl, onSubmit, onFocus }) {
         })
       }
 
-      onSubmit(keyword)
-    }
-  })
+      if (keyword === nextKeyword) {
+        return
+      }
 
-  new Image({
-    targetEl: searchBarEl,
-    initialState: {
-      imgUrl: SEARCH_ICON,
-      imgAlt: "search-icon"
+      this.setState({
+        ...this.state,
+        keyword: nextKeyword
+      })
+
+      onSubmit(nextKeyword)
     }
   })
 
@@ -60,5 +80,11 @@ export default function SearchBar({ targetEl, onSubmit, onFocus }) {
 
   searchInputEl.addEventListener("blur", (e) => {
     onFocus(false)
+  })
+
+  searchInputEl.addEventListener("keydown", (e) => {
+    if ([38, 40].indexOf(e.keyCode) > -1) {
+      e.preventDefault()
+    }
   })
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
-import App from './App';
+import App from "./App"
+import "@style/main.css"
 
-const targetEl = document.querySelector('#app');
+const targetEl = document.querySelector("#app")
 
 new App({
   targetEl
-});
+})

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -1,0 +1,12 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
+* {
+  font-family: "Spoqa Han Sans Neo", "sans-serif";
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  background: #1b1e1f;
+}

--- a/src/style/searchPage.css
+++ b/src/style/searchPage.css
@@ -1,0 +1,78 @@
+.header {
+  display: flex;
+  align-items: center;
+  margin: 30% 0 3%;
+  text-align: center;
+  letter-spacing: -0.017em;
+  font-weight: 700;
+  font-size: 4.5em;
+  line-height: 90px;
+  color: #ffd600;
+}
+
+.search-bar {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 3%;
+  padding: 0 3%;
+  margin: 0 10% 2%;
+  box-sizing: border-box;
+  width: 80%;
+  height: 55px;
+  background: #222326;
+  border-radius: 10px;
+}
+
+.search-bar input {
+  width: 100%;
+  height: 60%;
+  background: transparent;
+  border: none;
+  font-style: normal;
+  font-size: 1.2em;
+  line-height: 25px;
+  color: #afafaf;
+}
+
+.search-bar .search-clear {
+  visibility: hidden;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.search-bar .search-clear.visible {
+  visibility: visible;
+}
+
+.auto-complete {
+  display: none;
+  width: 80%;
+  padding: 2%;
+  margin: 0 10%;
+  box-sizing: border-box;
+  background: #282a2a;
+  border-radius: 10px;
+  color: #ffffff;
+  list-style: none;
+}
+
+.auto-complete li {
+  padding: 3%;
+  border-radius: 10px;
+  font-size: 1.3em;
+  cursor: pointer;
+}
+
+.auto-complete li.selected {
+  background: #494949;
+}
+
+.auto-complete li:hover {
+  padding: 3%;
+  background: #6a6a6a;
+  border-radius: 10px;
+  font-size: 1.3em;
+}


### PR DESCRIPTION
## 🔗 이슈 번호
closed #11 

## 📚 내용 설명
### style 적용
 **설명**
- `input`의 `value`가 있는 경우에만 `cancel` 버튼이 활성되도록 설정했습니다.
- `select`된 검색 키워드를 color 값을 변경하여 통해 표시합니다.
- 마우스 `hover`한 검색 키워드를 color 값을 변경하여 표시합니다.

## ⏳ 실행 화면
![캡처](https://user-images.githubusercontent.com/70738281/160230899-5dc1b895-4fc5-40c8-a3cf-b2634391e62d.PNG)


## 🔥 이슈
- **Search Bar컴포넌트**
  - input의 위, 아래 방향키로 발생하는 기본 이벤트를 막도록 처리했습니다.
  - 검색 아이콘인 `Image` 컴포넌트의 위치를 컨테이너 처음으로 이동시켰습니다.
  - `keyword`를 상태로 추가하여 새로 입력한 `value`와 현재 `keyword` 상태 값이 같은 경우 이벤트를 전달하지 않습니다.